### PR TITLE
uci: ignore empty move tokens in position commands

### DIFF
--- a/pkg/engine/uci/uci.go
+++ b/pkg/engine/uci/uci.go
@@ -367,7 +367,10 @@ func (d *Driver) process(ctx context.Context, in <-chan string) {
 
 					moves := strings.TrimSpace(strings.TrimPrefix(line, d.lastPosition))
 					for _, arg := range strings.Split(moves, " ") {
-						if arg == "moves" {
+						// strings.Split("", " ") is []string{""}, so a position line
+						// identical to the last one arrives here as a single empty
+						// move and ends the driver below.
+						if arg == "" || arg == "moves" {
 							continue
 						}
 
@@ -398,7 +401,7 @@ func (d *Driver) process(ctx context.Context, in <-chan string) {
 						move = true
 						continue
 					}
-					if !move {
+					if !move || arg == "" {
 						continue
 					}
 


### PR DESCRIPTION
`Driver.run`'s continuation fast path treats a `position` line that prefixes the previous one as "same game, apply the extra moves". When the line is *identical* to the previous one, the remainder is empty — and `strings.Split("", " ")` returns `[""]`, a one-element slice holding an empty string. That reaches `Engine.Move`, fails, and the loop `return`s, which ends the driver and the session.

`pkg/engine/uci/uci.go`:

```go
moves := strings.TrimSpace(strings.TrimPrefix(line, d.lastPosition))
for _, arg := range strings.Split(moves, " ") {
    if arg == "moves" {
        continue
    }
    if err := d.e.Move(ctx, arg); err != nil {
        logw.Errorf(ctx, "Invalid position move '%v': %v: %v", arg, line, err)
        return
    }
}
```

### Reproducing

Two identical `position` commands, nothing else:

```
uci
position fen rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
go movetime 300      → bestmove e2e3
position fen rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
go movetime 300      → nothing; the driver has returned
```

on the way out:

```
E uci.go:375] Invalid position move '': position fen rnbqkbnr/... : invalid move: invalid move: ''
```

### Why fix it rather than avoid it

A GUI *should* send `ucinewgame` when the position is from a different game — the comment above this branch quotes that line, and a GUI that omits it will hit this on its second game. That part is the GUI's fault, and I've fixed it on my side.

But it is also reachable inside a single game, where no `ucinewgame` is owed: **take a move back and play the same move again.** The engine is then legitimately asked to move from a position it has already been sent, with a character-identical FEN — counters included, since they are determined by the move sequence. That is ordinary GUI behaviour, and it ends the engine.

The second hunk guards the new-position loop for the same reason: `args` comes from `strings.Split(strings.TrimSpace(line), " ")`, so any line with repeated spaces carries empty tokens into `Move`.

### A separate question, if you want it separately

`return` on an unparseable move ends the driver, where UCI's own guidance is that an engine receiving a command it doesn't understand should ignore it. Over a pipe that reads as the engine vanishing mid-game with no `bestmove`; embedded it is worse — I run these engines as WebAssembly in a Web Worker and as a `c-archive` on iOS, and there the death is silent, so the caller only discovers it by timing out a move. Happy to send a second PR that logs and continues instead of returning, or to leave it if the current behaviour is deliberate.

I did not add a test, because the driver needs a real engine to exercise and I didn't want to guess at the shape you'd want. Glad to add one if you'll say where it belongs.

---

For context: this is from [botvinnik](https://botvinnik.app), which ships TUROCHAMP, BERNSTEIN and SARGON built from your source, with attribution, as WebAssembly and as native binaries. Thank you for them — an engine you can lose to for period-correct reasons is a lovely thing!
